### PR TITLE
Stop zoom in on button double tap for iOS

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -14,6 +14,7 @@ body {
   display: flex;
   font-family: sans-serif;
   background-color: #313739;
+  touch-action: manipulation;
 }
 
 button {


### PR DESCRIPTION
Should resolve #1 

Zoom on double-tap will still happen if the element is not a button. But should mitigate the UX pain-point of zooming when incrementing and decrementing values. 